### PR TITLE
Keep browser open in visible mode until user closes it

### DIFF
--- a/login_bot.py
+++ b/login_bot.py
@@ -114,6 +114,17 @@ def login(credentials_path: Path, headless: bool = True) -> None:
         # Optionally wait for navigation or additional steps here.
         wait.until(lambda drv: drv.current_url != LOGIN_URL)
         print("Login attempt submitted.")
+        if not headless:
+            print(
+                "The browser window will remain open so you can verify the login."
+                " Close it manually or press Enter here to exit."
+            )
+            try:
+                input("Press Enter to close the browser...")
+            except EOFError:
+                # When stdin is not available, fall back to waiting for the user
+                # to close the window manually.
+                print("No interactive input available; close the browser window manually.")
     finally:
         driver.quit()
 


### PR DESCRIPTION
## Summary
- keep the visible Chrome session open after submitting the login so users can verify the result
- prompt for input (with a fallback) before closing the browser when running with --show

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee4bee0d4832db06d9a03f60e01c0